### PR TITLE
テキスト教材のインポート機能の実装

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -24,9 +24,9 @@ ActiveRecord::Schema.define(version: 2021_03_10_012212) do
   end
 
   create_table "texts", force: :cascade do |t|
-    t.integer "genre"
-    t.string "title"
-    t.text "content"
+    t.integer "genre", default: 0, null: false
+    t.string "title", null: false
+    t.text "content", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,4 +1,4 @@
-require "csv"
+require 'csv'
 
 EMAIL = 'test@example.com'
 PASSWORD = 'password'
@@ -13,20 +13,20 @@ end
 Movie.destroy_all
 CSV.foreach('db/csv_data/movie_data.csv', headers: true) do |row|
   Movie.create(
-    genre: row["genre"].to_i,
-    title: row["title"],
-    url: row["url"]
+    genre: row['genre'].to_i,
+    title: row['title'],
+    url: row['url']
   )
 end
-puts "動画の初期データインポートに成功しました。"
+puts '動画の初期データインポートに成功しました。'
 
 # テキスト教材のcsvインポート
 Text.destroy_all
 CSV.foreach('db/csv_data/text_data.csv', headers: true) do |row|
   Text.create(
-    genre: row["genre"].to_i,
-    title: row["title"],
-    url: row["content"]
+    genre: row['genre'].to_i,
+    title: row['title'],
+    content: row['content']
   )
 end
-puts "テキストの初期データインポートに成功しました。"
+puts 'テキストの初期データインポートに成功しました。'

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -19,3 +19,14 @@ CSV.foreach('db/csv_data/movie_data.csv', headers: true) do |row|
   )
 end
 puts "動画の初期データインポートに成功しました。"
+
+# テキスト教材のcsvインポート
+Text.destroy_all
+CSV.foreach('db/csv_data/text_data.csv', headers: true) do |row|
+  Text.create(
+    genre: row["genre"].to_i,
+    title: row["title"],
+    url: row["content"]
+  )
+end
+puts "テキストの初期データインポートに成功しました。"


### PR DESCRIPTION
## issue 番号（必須）

close #19

## 実装内容

- db/seeds.rb に，テキスト教材のCSV（db/csv_data/text_data.csv）を読み込み texts テーブルにデータを投入する処理を追加
  - 先に Text.destroy_all を入れ，実行時にデータを初期化できるようにしておくこと
  - rails db:seed を実行し，Railsコンソールなどで初期データが入ることを確認すること

## 参考資料

- CSVデータインポート機能
  - [やんばるエキスパートアプリ](https://www.yanbaru-code.com/texts/217)
- Qiita記事（CSVファイルを作成してrails db:seedで大量のデータを投入する）(https://qiita.com/shunsuke284052/items/0a900aa8b2770d4810c4)

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
