### PR TITLE
display all texts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,3 +38,5 @@ group :development do
 end
 
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
+
+gem 'enum_help'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,6 +90,8 @@ GEM
     devise-bootstrap-views (1.1.0)
     devise-i18n (1.9.2)
       devise (>= 4.7.1)
+    enum_help (0.0.17)
+      activesupport (>= 3.0.0)
     erubi (1.10.0)
     ffi (1.14.2)
     formtastic (4.0.0)
@@ -257,6 +259,7 @@ DEPENDENCIES
   devise
   devise-bootstrap-views (~> 1.0)
   devise-i18n
+  enum_help
   jbuilder (~> 2.7)
   listen (~> 3.3)
   pg (~> 1.1)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -56,7 +56,7 @@ body {
   max-width: 1200px;
 }
 
-.card-box{ 
+.card-box{
   margin-bottom: 50px;
   padding-right: 15px;
   padding-left: 15px;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -55,3 +55,17 @@ body {
 .mw-xl {
   max-width: 1200px;
 }
+
+.card-box{ 
+  margin-bottom: 50px;
+  padding-right: 15px;
+  padding-left: 15px;
+}
+
+.card{
+  height: 350px;
+}
+
+img{
+  max-width: 100%;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -55,17 +55,3 @@ body {
 .mw-xl {
   max-width: 1200px;
 }
-
-.card-box{
-  margin-bottom: 50px;
-  padding-right: 15px;
-  padding-left: 15px;
-}
-
-.card{
-  height: 350px;
-}
-
-img{
-  max-width: 100%;
-}

--- a/app/assets/stylesheets/texts.scss
+++ b/app/assets/stylesheets/texts.scss
@@ -1,0 +1,18 @@
+// テキスト教材一覧ページ
+
+.text-container {
+  .card-box {
+    margin-bottom: 50px;
+    padding-right: 15px;
+    padding-left: 15px;
+    max-width: 400px;
+  }
+
+  .card {
+    height: 350px;
+  }
+
+  .text-card-img {
+    max-width: 100%;
+  }
+}

--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -1,4 +1,5 @@
 class TextsController < ApplicationController
   def index
+    @texts = Text.all
   end
 end

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -7,7 +7,7 @@ class Movie < ApplicationRecord
     ruby: 3,
     rails: 4,
     php: 5,
-    htmml: 6,
+    html: 6,
     javascript: 7,
     typescript: 8,
     react: 9,

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -7,7 +7,7 @@ class Text < ApplicationRecord
     ruby: 3,
     rails: 4,
     php: 5,
-    htmml: 6,
+    html: 6,
     javascript: 7,
     typescript: 8,
     react: 9,

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -1,11 +1,11 @@
-<div class="container">
+<div class="text-container">
   <div class="row">
 
       <% @texts.each do |text| %>
         <div class="card-box col-12 col-md-6 col-lg-4">
           <div class="card border-dark mb-3">
             <div class="bd-placeholder-img card-img-top">
-              <img src="https://d5izmuz0mcjzz.cloudfront.net/texts/no_image.jpg" alt="デフォルト画像">
+              <img class="text-card-img" src="https://d5izmuz0mcjzz.cloudfront.net/texts/no_image.jpg" alt="デフォルト画像">
             </div>
               <div class="card-body">
                 <h5 class="card-title"><%= text.title %></h5>

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -9,7 +9,7 @@
           </div>
             <div class="card-body">
               <h5 class="card-title"><%= text.title %></h5>
-              <p class="card-genre">【<%= text.genre %>】</p>
+              <p class="card-genre">【<%= text.genre_i18n %>】</p>
             </div>
         </div>
       </div>

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -1,19 +1,19 @@
 <div class="container">
-  <div class="row row-cols-3">
+  <div class="row">
 
-    <% @texts.each do |text| %>
-      <div class="card-box">
-        <div class="card border-dark mb-3">
-          <div class="bd-placeholder-img card-img-top">
-            <img src="https://d5izmuz0mcjzz.cloudfront.net/texts/no_image.jpg" alt="デフォルト画像">
-          </div>
-            <div class="card-body">
-              <h5 class="card-title"><%= text.title %></h5>
-              <p class="card-genre">【<%= text.genre_i18n %>】</p>
+      <% @texts.each do |text| %>
+        <div class="card-box col-12 col-md-6 col-lg-4">
+          <div class="card border-dark mb-3">
+            <div class="bd-placeholder-img card-img-top">
+              <img src="https://d5izmuz0mcjzz.cloudfront.net/texts/no_image.jpg" alt="デフォルト画像">
             </div>
+              <div class="card-body">
+                <h5 class="card-title"><%= text.title %></h5>
+                <p class="card-genre">【<%= text.genre_i18n %>】</p>
+              </div>
+          </div>
         </div>
-      </div>
-    <% end %>
+      <% end %>
 
   </div>
 </div>

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -1,2 +1,19 @@
-<%#動作確認用ボタン%>
-<button type="button" class="btn btn-primary">Primary</button>
+<div class="container">
+  <div class="row row-cols-3">
+
+    <% @texts.each do |text| %>
+      <div class="card-box">
+        <div class="card border-dark mb-3">
+          <div class="bd-placeholder-img card-img-top">
+            <img src="https://d5izmuz0mcjzz.cloudfront.net/texts/no_image.jpg" alt="デフォルト画像">
+          </div>
+            <div class="card-body">
+              <h5 class="card-title"><%= text.title %></h5>
+              <p class="card-genre">【<%= text.genre %>】</p>
+            </div>
+        </div>
+      </div>
+    <% end %>
+
+  </div>
+</div>

--- a/config/locales/enums.ja.yml
+++ b/config/locales/enums.ja.yml
@@ -1,0 +1,20 @@
+ja:
+  enums:
+    text:
+      genre:
+        invisible: "Invisible"
+        basic: "Basic"
+        git: "Git"
+        ruby: "Ruby"
+        rails: "Ruby on Rails"
+        php: "PHP"
+        html: "HTML"
+        javascript: "JavaScript"
+        typescript: "TypeScript"
+        react: "React"
+        vue: "Vue"
+        angular: "Angular"
+        aws: "AWS"
+        money: "マネタイズ"
+        talk: "対談"
+        live: "勉強会"


### PR DESCRIPTION
close #27 

## 実装内容

- Railsテキスト教材一覧ページの実装
  - テキスト教材用のCardsを作成
  - タイトルとジャンルを表記
  - enumに設定したジャンルの一覧表示での表記を変更
  - レスポンシブ対応の実装 

## 参考資料

- 【公式】Bootstrap Cards
  - (https://getbootstrap.jp/docs/4.5/components/card/)
- 【公式】Bootstrap Grid system
  - (https://getbootstrap.jp/docs/4.5/layout/grid/)

## チェックリスト

【補足】プルリクを出した後，クリックでチェックを入れて下さい

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
