### PR TITLE
Railsテキスト教材詳細ページの実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,3 +43,6 @@ gem 'enum_help'
 
 # マークダウン記法の文字列をHTMLに変換
 gem 'redcarpet'
+
+# シンタックスハイライト
+gem 'coderay'

--- a/Gemfile
+++ b/Gemfile
@@ -40,3 +40,6 @@ end
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 
 gem 'enum_help'
+
+# マークダウン記法の文字列をHTMLに変換
+gem 'redcarpet'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -202,6 +202,7 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    redcarpet (3.5.1)
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
@@ -268,6 +269,7 @@ DEPENDENCIES
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.1)
   rails-i18n (~> 6.0)
+  redcarpet
   sass-rails (>= 6)
   spring
   turbolinks (~> 5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -257,6 +257,7 @@ DEPENDENCIES
   activeadmin
   bootsnap (>= 1.4.4)
   byebug
+  coderay
   devise
   devise-bootstrap-views (~> 1.0)
   devise-i18n

--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -4,6 +4,6 @@ class TextsController < ApplicationController
   end
 
   def show
-    @text = Text.find_by(id:params[:id])
+    @text = Text.find(params[:id])
   end
 end

--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -2,4 +2,8 @@ class TextsController < ApplicationController
   def index
     @texts = Text.all
   end
+
+  def show
+    @text = Text.find_by(id:params[:id])
+  end
 end

--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -1,0 +1,27 @@
+module MarkdownHelper
+  def markdown(text)
+    markdown = Redcarpet::Markdown.new(html_renderer, markdown_extensions)
+    markdown.render(text).html_safe
+  end
+
+  private
+
+  def html_renderer
+    Redcarpet::Render::HTML
+  end
+
+  def markdown_extensions
+    # 設定の詳細は https://github.com/vmg/redcarpet#and-its-like-really-simple-to-use
+    {
+      autolink: true,
+      space_after_headers: true,
+      no_intra_emphasis: true,
+      fenced_code_blocks: true,
+      tables: true,
+      hard_wrap: true,
+      xhtml: true,
+      lax_html_blocks: true,
+      strikethrough: true
+    }
+  end
+end

--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -7,11 +7,14 @@ module MarkdownHelper
   private
 
   def html_renderer
-    Redcarpet::Render::HTML
+      ::Coderayify.new(
+      filter_html: true,
+      hard_wrap: true,
+      link_attributes: { rel: 'nofollow', target: "_blank" }
+    )
   end
 
   def markdown_extensions
-    # 設定の詳細は https://github.com/vmg/redcarpet#and-its-like-really-simple-to-use
     {
       autolink: true,
       space_after_headers: true,

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -8,7 +8,7 @@
               <img class="text-card-img" src="https://d5izmuz0mcjzz.cloudfront.net/texts/no_image.jpg" alt="デフォルト画像">
             </div>
               <div class="card-body">
-                <h5 class="card-title"><%= text.title %></h5>
+                <h5 class="card-title"><%= link_to text.title,"/texts/#{text.id}" %></h5>
                 <p class="card-genre">【<%= text.genre_i18n %>】</p>
               </div>
           </div>

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -3,17 +3,20 @@
 
       <% @texts.each do |text| %>
         <div class="card-box col-12 col-md-6 col-lg-4">
-          <div class="card border-dark mb-3">
-            <div class="bd-placeholder-img card-img-top">
-              <img class="text-card-img" src="https://d5izmuz0mcjzz.cloudfront.net/texts/no_image.jpg" alt="デフォルト画像">
-            </div>
-              <div class="card-body">
-                <h5 class="card-title"><%= link_to text.title,"/texts/#{text.id}" %></h5>
-                <p class="card-genre">【<%= text.genre_i18n %>】</p>
+          <%= link_to "/texts/#{text.id}" do %>
+            <div class="card border-dark mb-3">
+              <div class="bd-placeholder-img card-img-top">
+                <img class="text-card-img" src="https://d5izmuz0mcjzz.cloudfront.net/texts/no_image.jpg" alt="デフォルト画像">
               </div>
-          </div>
+                <div class="card-body">
+                  <h5 class="card-title"><%= text.title %></h5>
+                  <p class="card-genre">【<%= text.genre_i18n %>】</p>
+                </div>
+            </div>
+          <% end %>
         </div>
       <% end %>
-
+      
   </div>
 </div>
+

--- a/app/views/texts/show.html.erb
+++ b/app/views/texts/show.html.erb
@@ -1,1 +1,3 @@
-<p><%= @text.content%>
+<p>
+  <%= markdown(@text.content) %>
+</p>

--- a/app/views/texts/show.html.erb
+++ b/app/views/texts/show.html.erb
@@ -1,4 +1,4 @@
-<h1><%= markdown(@text.title) %></h1>
+<h1><%= @text.title %></h1>
 <p>
   <%= markdown(@text.content) %>
 </p>

--- a/app/views/texts/show.html.erb
+++ b/app/views/texts/show.html.erb
@@ -1,0 +1,1 @@
+<p><%= @text.content%>

--- a/app/views/texts/show.html.erb
+++ b/app/views/texts/show.html.erb
@@ -1,3 +1,4 @@
+<h1><%= markdown(@text.title) %></h1>
 <p>
   <%= markdown(@text.content) %>
 </p>

--- a/config/application.rb
+++ b/config/application.rb
@@ -28,6 +28,9 @@ module TeamProject
     config.i18n.default_locale = :ja
     config.time_zone = "Asia/Tokyo"
 
+    # lib/autoloads ディレクトリ配下のファイルを読み込む
+    config.autoload_paths << Rails.root.join("lib/autoloads")
+
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,4 +3,5 @@ Rails.application.routes.draw do
   ActiveAdmin.routes(self)
   devise_for :users
   root "texts#index"
+  get '/texts/:id', to: 'texts#show'
 end

--- a/lib/autoloads/coderayify.rb
+++ b/lib/autoloads/coderayify.rb
@@ -1,0 +1,34 @@
+class Coderayify < Redcarpet::Render::HTML
+  def block_code(code, language)
+    # コードブロックの拡張子を取得
+    ext = retrieve_extension(language)
+    # 適用するシンタックスハイライトの言語を決める
+    lang = case ext
+           when "rb"
+             :ruby
+           when "yml"
+             :yaml
+           else
+             ext.to_sym
+           end
+    CodeRay.scan(code, lang).div
+  end
+
+  private
+
+  # 拡張子を取得するメソッド
+  def retrieve_extension(language)
+    if language.blank?
+      # コードブロックの開始宣言で「```」の後に拡張子が与えられていない場合は md 形式とみなす
+      "md"
+    elsif language.include?(":")
+      # コードブロックの開始宣言が「```rb:sample.rb」の場合は rb 形式とみなす
+      language.split(':')[0]
+    elsif language.include?(".")
+      # コードブロックの開始宣言が「```sample.rb」の場合は rb 形式とみなす
+      language.split('.')[-1]
+    else
+      language
+    end
+  end
+end


### PR DESCRIPTION
## issue 番号（必須）

close #38

## 実装内容

- 一覧ページから詳細ページに移動できるようにする
  - テキスト詳細ページのルーティング，アクション追加/viewファイル作成
- 「内容（content）」は Markdown に対応した表示ができるようにする
  - Redcarpetを導入
  - シンタックスハイライトが使用できるようCodeRayを適用

## 参考資料

- ログイン機能
  - [やんばるエキスパート教材「CRUD処理の実装」](https://www.yanbaru-code.com/texts/211)
  - [やんばるエキスパート教材「メッセージ投稿アプリ（その1・CRUD処理）」](https://www.yanbaru-code.com/texts/269)

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
