### PR TITLE
Feature/create read progress function

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -55,3 +55,7 @@ body {
 .mw-xl {
   max-width: 1200px;
 }
+
+a {
+  text-decoration: none !important;
+}

--- a/app/assets/stylesheets/texts.scss
+++ b/app/assets/stylesheets/texts.scss
@@ -15,4 +15,16 @@
   .text-card-img {
     max-width: 100%;
   }
+
+  .card-title {
+    font-size: 16px;
+    color: black;
+  }
+
+  .card-genre {
+    color: black;
+  }
+  .read-button {
+    margin: 15px 15px;
+  }
 }

--- a/app/controllers/read_progresses_controller.rb
+++ b/app/controllers/read_progresses_controller.rb
@@ -1,11 +1,13 @@
 class ReadProgressesController < ApplicationController
   def create
+    @text = Text.find(params[:text_id])
     current_user.read_progresses.create!(text_id: params[:text_id])
-    redirect_back(fallback_location: root_path)
+    # redirect_back(fallback_location: root_path)
   end
 
   def destroy
+    @text = Text.find(params[:text_id])
     current_user.read_progresses.find_by(text_id: params[:text_id]).destroy!
-    redirect_back(fallback_location: root_path)
+    # redirect_back(fallback_location: root_path)
   end
 end

--- a/app/controllers/read_progresses_controller.rb
+++ b/app/controllers/read_progresses_controller.rb
@@ -2,12 +2,10 @@ class ReadProgressesController < ApplicationController
   def create
     @text = Text.find(params[:text_id])
     current_user.read_progresses.create!(text_id: params[:text_id])
-    # redirect_back(fallback_location: root_path)
   end
 
   def destroy
     @text = Text.find(params[:text_id])
     current_user.read_progresses.find_by(text_id: params[:text_id]).destroy!
-    # redirect_back(fallback_location: root_path)
   end
 end

--- a/app/controllers/read_progresses_controller.rb
+++ b/app/controllers/read_progresses_controller.rb
@@ -1,0 +1,11 @@
+class ReadProgressesController < ApplicationController
+  def create
+    current_user.read_progresses.create!(text_id: params[:text_id])
+    redirect_back(fallback_location: root_path)
+  end
+
+  def destroy
+    current_user.read_progresses.find_by(text_id: params[:text_id]).destroy!
+    redirect_back(fallback_location: root_path)
+  end
+end

--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -1,6 +1,7 @@
 class TextsController < ApplicationController
   def index
-    @texts = Text.all
+    select_sql = "texts.*, read_progresses.user_id = #{current_user.id} AS read"
+    @texts = Text.includes(:user).left_join_read_texts(current_user.id).select(select_sql).order(:created_at)
   end
 
   def show

--- a/app/models/read_progress.rb
+++ b/app/models/read_progress.rb
@@ -1,0 +1,9 @@
+class ReadProgress < ApplicationRecord
+  belongs_to :user
+  belongs_to :text
+
+  validates :user_id, uniquness: {
+                        scope: :text_id,
+                        message: "は同じ教材に2回以上読破済みとすることは出来ません"、
+                      }
+end

--- a/app/models/read_progress.rb
+++ b/app/models/read_progress.rb
@@ -2,8 +2,8 @@ class ReadProgress < ApplicationRecord
   belongs_to :user
   belongs_to :text
 
-  validates :user_id, uniquness: {
+  validates :user_id, uniqueness: {
                         scope: :text_id,
-                        message: "は同じ教材に2回以上読破済みとすることは出来ません"、
+                        message: "は同じ教材に2回以上読破済みとすることは出来ません",
                       }
 end

--- a/app/models/read_progress.rb
+++ b/app/models/read_progress.rb
@@ -4,6 +4,6 @@ class ReadProgress < ApplicationRecord
 
   validates :user_id, uniqueness: {
                         scope: :text_id,
-                        message: "は同じ教材に2回以上読破済みとすることは出来ません",
+                        message: "は同じテキスト教材を2回以上読破済みにはできません",
                       }
 end

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -1,4 +1,7 @@
 class Text < ApplicationRecord
+  belongs_to :user
+  has_many :read_progresses, dependent: :destroy
+
   validates :genre, :title, :content, presence: true
   enum genre: {
     invisible: 0,

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -25,4 +25,12 @@ class Text < ApplicationRecord
   def clicked_read_button?(user)
     read_progresses.exists?(user_id: user.id)
   end
+
+  def self.left_join_read_texts(user_id)
+    join_sql = <<~SQL.squish
+      LEFT OUTER JOIN read_progresses ON read_progresses.text_id = texts.id
+                                      AND read_progresses.user_id = #{user_id}
+    SQL
+    joins(join_sql)
+  end
 end

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -21,4 +21,8 @@ class Text < ApplicationRecord
     talk: 14,
     live: 15,
   }
+
+  def clicked_read_button?(user)
+    read_progresses.exists?(user_id: user.id)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,9 @@
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
+  has_many :texts, dependent: :destroy
+  has_many :read_progresses, dependent: :destroy
+
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
   def self.guest

--- a/app/views/read_progresses/create.js.erb
+++ b/app/views/read_progresses/create.js.erb
@@ -1,0 +1,1 @@
+document.getElementById('text-<%= @text.id %>').innerHTML = '<%= j render("texts/read", text: @text) %>'

--- a/app/views/read_progresses/destroy.js.erb
+++ b/app/views/read_progresses/destroy.js.erb
@@ -1,0 +1,1 @@
+document.getElementById('text-<%= @text.id %>').innerHTML = '<%= j render("texts/unread", text: @text) %>'

--- a/app/views/texts/_read.html.erb
+++ b/app/views/texts/_read.html.erb
@@ -1,2 +1,2 @@
 <%# 読破済み(クリックすると「読破済み解除」になる) %>
-<%= link_to "読破済みを解除", text_read_progresses_path(text), method: :delete %>
+<%= link_to "読破済みを解除", text_read_progresses_path(text), method: :delete, remote: true %>

--- a/app/views/texts/_read.html.erb
+++ b/app/views/texts/_read.html.erb
@@ -1,2 +1,2 @@
-<%# 読破済み(クリックすると「読破済み解除」になる) %>
+<%# 「読破済みにする」の状態(クリックすると「読破済みを解除」になる) %>
 <%= link_to "読破済みを解除", text_read_progresses_path(text), method: :delete, remote: true, class: 'btn btn-primary btn-block' %>

--- a/app/views/texts/_read.html.erb
+++ b/app/views/texts/_read.html.erb
@@ -1,0 +1,2 @@
+<%# 読破済み(クリックすると「読破済み解除」になる) %>
+<%= link_to "読破済みを解除", text_read_progresses_path(text), method: :delete %>

--- a/app/views/texts/_read.html.erb
+++ b/app/views/texts/_read.html.erb
@@ -1,2 +1,2 @@
 <%# 読破済み(クリックすると「読破済み解除」になる) %>
-<%= link_to "読破済みを解除", text_read_progresses_path(text), method: :delete, remote: true %>
+<%= link_to "読破済みを解除", text_read_progresses_path(text), method: :delete, remote: true, class: 'btn btn-primary btn-block' %>

--- a/app/views/texts/_unread.html.erb
+++ b/app/views/texts/_unread.html.erb
@@ -1,0 +1,2 @@
+<%# 「読破済みにする」ではない(クリックすると「読破済みを解除」になる) %>
+<%= link_to "読破済みにする", text_read_progresses_path(text), method: :post %>

--- a/app/views/texts/_unread.html.erb
+++ b/app/views/texts/_unread.html.erb
@@ -1,2 +1,2 @@
-<%# 「読破済みにする」ではない(クリックすると「読破済みを解除」になる) %>
+<%# 「読破済みを解除」の状態(クリックすると「読破済みにする」になる) %>
 <%= link_to "読破済みにする", text_read_progresses_path(text), method: :post, remote: true, class: 'btn btn-secondary btn-block'%>

--- a/app/views/texts/_unread.html.erb
+++ b/app/views/texts/_unread.html.erb
@@ -1,2 +1,2 @@
 <%# 「読破済みにする」ではない(クリックすると「読破済みを解除」になる) %>
-<%= link_to "読破済みにする", text_read_progresses_path(text), method: :post, remote: true %>
+<%= link_to "読破済みにする", text_read_progresses_path(text), method: :post, remote: true, class: 'btn btn-secondary btn-block'%>

--- a/app/views/texts/_unread.html.erb
+++ b/app/views/texts/_unread.html.erb
@@ -1,2 +1,2 @@
 <%# 「読破済みにする」ではない(クリックすると「読破済みを解除」になる) %>
-<%= link_to "読破済みにする", text_read_progresses_path(text), method: :post %>
+<%= link_to "読破済みにする", text_read_progresses_path(text), method: :post, remote: true %>

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -1,22 +1,24 @@
 <div class="text-container">
   <div class="row">
-
-      <% @texts.each do |text| %>
-        <div class="card-box col-12 col-md-6 col-lg-4">
-          <%= link_to "/texts/#{text.id}" do %>
-            <div class="card border-dark mb-3">
-              <div class="bd-placeholder-img card-img-top">
-                <img class="text-card-img" src="https://d5izmuz0mcjzz.cloudfront.net/texts/no_image.jpg" alt="デフォルト画像">
-              </div>
-                <div class="card-body">
-                  <h5 class="card-title"><%= text.title %></h5>
-                  <p class="card-genre">【<%= text.genre_i18n %>】</p>
-                </div>
+    <% @texts.each do |text| %>
+      <div class="card-box col-12 col-md-6 col-lg-4">
+        <%= link_to "/texts/#{text.id}" do %>
+          <div class="card border-dark mb-3">
+            <div class="bd-placeholder-img card-img-top">
+              <img class="text-card-img" src="https://d5izmuz0mcjzz.cloudfront.net/texts/no_image.jpg" alt="デフォルト画像">
             </div>
-          <% end %>
-        </div>
-      <% end %>
-      
+            <div class="card-body">
+              <h5 class="card-title"><%= text.title %></h5>
+              <p class="card-genre">【<%= text.genre_i18n %>】</p>
+            </div>
+            <%if text.clicked_read_button?(current_user) %>
+              <%= render "read", text: text %>
+            <% else %>
+              <%= render "unread", text: text %>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
+    <% end %>
   </div>
 </div>
-

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -7,17 +7,17 @@
             <div class="bd-placeholder-img card-img-top">
               <img class="text-card-img" src="https://d5izmuz0mcjzz.cloudfront.net/texts/no_image.jpg" alt="デフォルト画像">
             </div>
-            <div class="card-body">
-              <h5 class="card-title"><%= text.title %></h5>
-              <p class="card-genre">【<%= text.genre_i18n %>】</p>
-            </div>
-            <p id="text-<%= text.id %>">
+            <object class="read-button" id="text-<%= text.id %>">
               <%if text.clicked_read_button?(current_user) %>
                 <%= render "read", text: text %>
               <% else %>
                 <%= render "unread", text: text %>
               <% end %>
-            </p>
+            </object>
+            <div class="card-body">
+              <h5 class="card-title"><%= text.title %></h5>
+              <p class="card-genre">【<%= text.genre_i18n %>】</p>
+            </div>
           </div>
         <% end %>
       </div>

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -11,11 +11,13 @@
               <h5 class="card-title"><%= text.title %></h5>
               <p class="card-genre">【<%= text.genre_i18n %>】</p>
             </div>
-            <%if text.clicked_read_button?(current_user) %>
-              <%= render "read", text: text %>
-            <% else %>
-              <%= render "unread", text: text %>
-            <% end %>
+            <p id="text-<%= text.id %>">
+              <%if text.clicked_read_button?(current_user) %>
+                <%= render "read", text: text %>
+              <% else %>
+                <%= render "unread", text: text %>
+              <% end %>
+            </p>
           </div>
         <% end %>
       </div>

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -8,7 +8,7 @@
               <img class="text-card-img" src="https://d5izmuz0mcjzz.cloudfront.net/texts/no_image.jpg" alt="デフォルト画像">
             </div>
             <object class="read-button" id="text-<%= text.id %>">
-              <%if text.clicked_read_button?(current_user) %>
+              <%if text.read %>
                 <%= render "read", text: text %>
               <% else %>
                 <%= render "unread", text: text %>

--- a/config/locales/enums.ja.yml
+++ b/config/locales/enums.ja.yml
@@ -2,19 +2,27 @@ ja:
   enums:
     text:
       genre:
-        invisible: "Invisible"
-        basic: "Basic"
-        git: "Git"
-        ruby: "Ruby"
-        rails: "Ruby on Rails"
-        php: "PHP"
-        html: "HTML"
-        javascript: "JavaScript"
-        typescript: "TypeScript"
-        react: "React"
-        vue: "Vue"
-        angular: "Angular"
-        aws: "AWS"
-        money: "マネタイズ"
-        talk: "対談"
-        live: "勉強会"
+        invisible: 'Invisible'
+        basic: 'Basic'
+        git: 'Git'
+        ruby: 'Ruby'
+        rails: 'Ruby on Rails'
+        php: 'PHP'
+        html: 'HTML'
+        javascript: 'JavaScript'
+        typescript: 'TypeScript'
+        react: 'React'
+        vue: 'Vue'
+        angular: 'Angular'
+        aws: 'AWS'
+        money: 'マネタイズ'
+        talk: '対談'
+        live: '勉強会'
+  activerecord:
+    models:
+      text: テキスト教材
+      read_progress: 読破済み
+    attributes:
+      read_progress:
+        user: ユーザー
+        text: テキスト教材

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,10 @@ Rails.application.routes.draw do
   root "texts#index"
   get "/texts/:id", to: "texts#show"
 
+  resources :texts do
+    resource :read_progresses, only: [:create, :destroy]
+  end
+
   devise_scope :user do
     post "users/guest_sign_in", to: "users/sessions#guest_sign_in"
   end

--- a/db/migrate/20210615062018_create_read_progresses.rb
+++ b/db/migrate/20210615062018_create_read_progresses.rb
@@ -1,0 +1,11 @@
+class CreateReadProgresses < ActiveRecord::Migration[6.1]
+  def change
+    create_table :read_progresses do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :text, null: false, foreign_key: true
+
+      t.timestamps
+    end
+    add_index :read_progresses, [:user_id, :text_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_21_030246) do
+ActiveRecord::Schema.define(version: 2021_06_15_062018) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -49,6 +49,16 @@ ActiveRecord::Schema.define(version: 2021_03_21_030246) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
+  create_table "read_progresses", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "text_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["text_id"], name: "index_read_progresses_on_text_id"
+    t.index ["user_id", "text_id"], name: "index_read_progresses_on_user_id_and_text_id", unique: true
+    t.index ["user_id"], name: "index_read_progresses_on_user_id"
+  end
+
   create_table "texts", force: :cascade do |t|
     t.integer "genre", default: 0, null: false
     t.string "title", null: false
@@ -69,4 +79,6 @@ ActiveRecord::Schema.define(version: 2021_03_21_030246) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "read_progresses", "texts"
+  add_foreign_key "read_progresses", "users"
 end


### PR DESCRIPTION
## 45

close #45 

## 実装内容

- `ReadProgress` モデルを作成
  - 外部キー設定と、ユニーク制約を追加
  - モデルにバリデーションと関連付けの追加
  - モデルに日本語訳を追加
- テキスト教材一覧ページに読破済み機能を実装
  - `text` モデルに読破済みの判定のメソッドを追加
  - `ReadProgress` のためのルーティングの作成
  - `ReadProgress`コントローラに`create` と`destroy` アクションの追加
  - 読破済み(`_read`)、未読(`_unread`)の部分テンプレート作成
  - 一覧ページに `render` を使用して条件分岐で `_read`, `_unread` を追記
- 読破済みボタンを押した際のリロードを回避するために非同期処理を追加
  - `views/read_progresses/` に`create.js.erb` と`destroy.js.erb`を作成し、処理を記述
- 読破済みボタンへスタイルを適用
- N + 1 問題の対処
## 参考資料

- [【やんばるエキスパート教材】モデルの関連付け その2（多対多）](https://www.yanbaru-code.com/texts/297)

## チェックリスト

【補足】プルリクを出した後，クリックでチェックを入れて下さい

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
