### PR TITLE
Feature/divide genre of movie

### DIFF
--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,5 +1,10 @@
 class MoviesController < ApplicationController
   def index
-    @movies = Movie.includes(:watch_progresses).where(genre: Movie::RAILS_GENRE_LIST)
+    @movies = 
+    if params[:genre] == "php"
+      Movie.where(genre: Movie::PHP_GENRE_LIST)
+    else
+      Movie.where(genre: Movie::RAILS_GENRE_LIST)
+    end
   end
 end

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -22,6 +22,8 @@ class Movie < ApplicationRecord
     live: 15,
   }
 
+  PHP_GENRE_LIST = %w[php]
+
   def watch_progressed_by?(user)
     watch_progresses.any? { |watch_progress| watch_progress.user_id == user.id }
   end

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -1,4 +1,10 @@
-<h2 class="text-center">Ruby/Rails教材</h2>
+<div class="text-center">
+  <% if params[:genre] == "php" %>
+    <h1>PHP動画</h1>
+  <% else %>
+    <h1>Ruby/Rails動画</h1>
+  <% end %>
+</div>  
 <div class="movie-container">
   <div class="row">
     <%= render partial: "movie", collection: @movies %>


### PR DESCRIPTION
close #41

## 実装内容

- PHP動画教材ページで「PHPの動画教材のみ」が表示されるように修正

  - PHP動画教材 のリンクをクリックした際のクエリパラメータ ?genre=php を利用
  - モデルにクラスメソッドを作成して対応できるとなおよいでしょう（→未対応）
  
- 「Ruby/Rails動画教材ページ」のタイトルは「Ruby/Rails 動画」，「PHP動画教材ページ」のタイトルは「PHP 動画」とする

  - app/helpers/application_helper.rb にメソッドを作成して対応できるとなおよいでしょう（→未対応）

## チェックリスト

【補足】プルリクを出した後，クリックでチェックを入れて下さい

- [ ] GitHub で Files changed を確認
- [ ] 影響し得る範囲のローカル環境での動作確認