### PR TITLE
テキスト教材ページのジャンル分け

### DIFF
--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -1,7 +1,7 @@
 class TextsController < ApplicationController
   def index
     select_sql = "texts.*, read_progresses.user_id = #{current_user.id} AS read"
-    @texts = Text.includes(:user).left_join_read_texts(current_user.id).select(select_sql).order(:created_at)
+    @texts = Text.includes(:user).left_join_read_texts(current_user.id).select(select_sql).order(:created_at).filter_by(params[:genre])
   end
 
   def show

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,4 +2,12 @@ module ApplicationHelper
   def max_width
     "mw-xl"
   end
+
+  def text_title
+    if params["genre"] == "php"
+      "PHP テキスト教材"
+    else
+      "Ruby/Rails テキスト教材"
+    end
+  end
 end

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -21,6 +21,17 @@ class Text < ApplicationRecord
     talk: 14,
     live: 15,
   }
+  RAILS_GENRE_LIST = %w[basic git ruby rails].freeze
+
+  PHP_GENRE_LIST = %w[php].freeze
+
+  def self.filter_by(genre)
+    if genre == "php"
+      Text.where(genre: Text::PHP_GENRE_LIST)
+    else
+      Text.where(genre: Text::RAILS_GENRE_LIST)
+    end
+  end
 
   def clicked_read_button?(user)
     read_progresses.exists?(user_id: user.id)

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -1,4 +1,7 @@
 <div class="text-container">
+  <h1 class="text-center">
+    <%= text_title %>
+  </h1>
   <div class="row">
     <% @texts.each do |text| %>
       <div class="card-box col-12 col-md-6 col-lg-4">


### PR DESCRIPTION

## issue 番号（必須）

close #43

## 実装内容

- PHPテキスト教材ページで「PHPのテキスト教材のみ」が表示されるように修正
  - PHPテキスト教材 のリンクをクリックした際のクエリパラメータ ?genre=php を利用
  - モデルにクラスメソッドを作成して対応できるとなおよいでしょう
- 「Ruby/Railsテキスト教材ページ」のタイトルは「Ruby/Rails テキスト教材」，「PHPテキスト教材ページ」のタイトルは「PHP テキスト教材」とする
 - 「新タスク18」の app/helpers/application_helper.rb にメソッドを利用して対応できるとなおよいでしょう

##動作確認

- 「Ruby/Railsテキスト教材」に「PHPテキスト教材」が含まれていないことを確認
- 「PHPテキスト教材」に「PHPテキスト教材」のみが表示されていることを確認
- クエリパラメータ ?genre=php を php 以外に変更してアクセスした際は「Ruby/Railsテキスト教材」が表示されることを確認

## チェックリスト

【補足】プルリクを出した後，クリックでチェックを入れて下さい

- [ ] GitHub で Files changed を確認
- [ ] 影響し得る範囲のローカル環境での動作確認